### PR TITLE
Add executable product for pfw to support SPM tool backends

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -7,6 +7,12 @@ let package = Package(
   platforms: [
     .macOS(.v15)
   ],
+  products: [
+        .executable(
+            name: "pfw",
+            targets: ["pfw"]
+        ),
+  ],
   dependencies: [
     .package(url: "https://github.com/apple/swift-argument-parser", from: "1.5.0"),
     .package(url: "https://github.com/weichsel/ZIPFoundation", from: "0.9.20"),


### PR DESCRIPTION
## Summary

This PR adds an explicit `pfw` executable product to `Package.swift`.

The package already defines an `.executableTarget(name: "pfw", ...)`, but it does not currently expose an executable product. This change surfaces the existing CLI target as a first-class executable product without altering targets, dependencies, or behavior.

## Motivation

Some Swift tooling that installs CLI tools (for example, the SPM backend in [mise](https://mise.jdx.dev/dev-tools/backends/spm.html)) discovers executables by:

1. Running `swift package dump-package`
2. Inspecting the `products` list for executable products

Because `pfw` only defined an executable target and no executable product, these tools could not see `pfw` as an installable executable and would fail with “No executables found in the package”.

Adding an executable product makes `pfw` discoverable for such SPM-based tool backends.

## Verification

- Ran `swift package dump-package` and verified that `pfw` appears in the `products` list as an executable.
- Tagged the change in my fork and installed `pfw` via mise’s SPM backend from that fork, confirming that installation and running the tool both work as expected.