### PR TITLE
Add support for more AI tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,5 +21,20 @@ A CLI tool for downloading and managing [Point-Free Way](https://www.pointfree.c
 3. **Fetch the latest Point-Free Way skills**
 
     ```sh
-    $ pfw install
+    $ pfw install --tool codex
     ```
+
+## Supported AI Tools
+
+| Tool | Install Path | Documentation |
+|------|--------------|---------------|
+| Codex | `~/.codex/skills` | [OpenAI Codex Skills](https://developers.openai.com/codex/skills/) |
+| Claude | `~/.claude/skills` | [Claude Code Skills](https://code.claude.com/docs/en/skills) |
+| Cursor | `~/.cursor/skills` | [Cursor Skills](https://cursor.com/docs/context/skills) |
+| Copilot | `~/.copilot/skills` | [GitHub Copilot Agent Skills](https://docs.github.com/en/copilot/concepts/agents/about-agent-skills) |
+| Kiro | `~/.kiro/skills` | [Kiro Skills](https://kiro.dev/docs/cli/custom-agents/configuration-reference/#skill-resources) |
+| Gemini | `~/.gemini/skills` | [Gemini CLI Skills](https://geminicli.com/docs/cli/skills/) |
+| Antigravity | `~/.gemini/antigravity/global_skills` | [Antigravity Skills](https://antigravity.google/docs/skills) |
+| OpenCode | `~/.config/opencode/skills` | [OpenCode Skills](https://opencode.ai/docs/skills/) |
+| Kimi | `~/.kimi/skills` | [Kimi CLI Skills](https://moonshotai.github.io/kimi-cli/en/customization/skills) |
+| Droid | `~/.factory/skills` | [Factory Droid Skills](https://docs.factory.ai/cli/configuration/skills) |

--- a/Sources/pfw/Install.swift
+++ b/Sources/pfw/Install.swift
@@ -10,11 +10,39 @@ struct Install: AsyncParsableCommand {
   enum Tool: String, CaseIterable, ExpressibleByArgument {
     case codex
     case claude
+    case cursor
+    case copilot
+    case kiro
+    case gemini
+    case antigravity
+    case opencode
+    case kimi
+    case droid
+
     var defaultInstallPath: URL {
       @Dependency(\.fileSystem) var fileSystem
-      return fileSystem.homeDirectoryForCurrentUser
-        .appending(path: ".\(rawValue)")
-        .appending(path: "skills")
+      let home = fileSystem.homeDirectoryForCurrentUser
+
+      switch self {
+      case .antigravity:
+        return home
+          .appending(path: ".gemini")
+          .appending(path: "antigravity")
+          .appending(path: "global_skills")
+      case .opencode:
+        return home
+          .appending(path: ".config")
+          .appending(path: "opencode")
+          .appending(path: "skills")
+      case .droid:
+        return home
+          .appending(path: ".factory")
+          .appending(path: "skills")
+      default:
+        return home
+          .appending(path: ".\(rawValue)")
+          .appending(path: "skills")
+      }
     }
   }
 

--- a/Tests/pfwTests/InstallTests.swift
+++ b/Tests/pfwTests/InstallTests.swift
@@ -335,6 +335,248 @@ extension BaseSuite {
         }
       }
 
+      @Test func cursor() async throws {
+        try await assertCommand(["install", "--tool", "cursor"]) {
+          """
+          Installed skills for cursor into /Users/blob/.cursor/skills
+          """
+        }
+        assertInlineSnapshot(of: fileSystem, as: .description) {
+          """
+          Users/
+            blob/
+              .cursor/
+                skills/
+                  pfw-ComposableArchitecture@ -> /Users/blob/.pfw/skills/ComposableArchitecture
+                  pfw-SQLiteData@ -> /Users/blob/.pfw/skills/SQLiteData
+              .pfw/
+                machine "00000000-0000-0000-0000-000000000001"
+                sha "cafebeef"
+                skills/
+                  ComposableArchitecture/
+                    SKILL.md "# Composable Architecture"
+                    references/
+                      navigation.md "# Navigation"
+                  SQLiteData/
+                    SKILL.md "# SQLiteData"
+                token "deadbeef"
+          tmp/
+          """
+        }
+      }
+
+      @Test func copilot() async throws {
+        try await assertCommand(["install", "--tool", "copilot"]) {
+          """
+          Installed skills for copilot into /Users/blob/.copilot/skills
+          """
+        }
+        assertInlineSnapshot(of: fileSystem, as: .description) {
+          """
+          Users/
+            blob/
+              .copilot/
+                skills/
+                  pfw-ComposableArchitecture@ -> /Users/blob/.pfw/skills/ComposableArchitecture
+                  pfw-SQLiteData@ -> /Users/blob/.pfw/skills/SQLiteData
+              .pfw/
+                machine "00000000-0000-0000-0000-000000000001"
+                sha "cafebeef"
+                skills/
+                  ComposableArchitecture/
+                    SKILL.md "# Composable Architecture"
+                    references/
+                      navigation.md "# Navigation"
+                  SQLiteData/
+                    SKILL.md "# SQLiteData"
+                token "deadbeef"
+          tmp/
+          """
+        }
+      }
+
+      @Test func kiro() async throws {
+        try await assertCommand(["install", "--tool", "kiro"]) {
+          """
+          Installed skills for kiro into /Users/blob/.kiro/skills
+          """
+        }
+        assertInlineSnapshot(of: fileSystem, as: .description) {
+          """
+          Users/
+            blob/
+              .kiro/
+                skills/
+                  pfw-ComposableArchitecture@ -> /Users/blob/.pfw/skills/ComposableArchitecture
+                  pfw-SQLiteData@ -> /Users/blob/.pfw/skills/SQLiteData
+              .pfw/
+                machine "00000000-0000-0000-0000-000000000001"
+                sha "cafebeef"
+                skills/
+                  ComposableArchitecture/
+                    SKILL.md "# Composable Architecture"
+                    references/
+                      navigation.md "# Navigation"
+                  SQLiteData/
+                    SKILL.md "# SQLiteData"
+                token "deadbeef"
+          tmp/
+          """
+        }
+      }
+
+      @Test func gemini() async throws {
+        try await assertCommand(["install", "--tool", "gemini"]) {
+          """
+          Installed skills for gemini into /Users/blob/.gemini/skills
+          """
+        }
+        assertInlineSnapshot(of: fileSystem, as: .description) {
+          """
+          Users/
+            blob/
+              .gemini/
+                skills/
+                  pfw-ComposableArchitecture@ -> /Users/blob/.pfw/skills/ComposableArchitecture
+                  pfw-SQLiteData@ -> /Users/blob/.pfw/skills/SQLiteData
+              .pfw/
+                machine "00000000-0000-0000-0000-000000000001"
+                sha "cafebeef"
+                skills/
+                  ComposableArchitecture/
+                    SKILL.md "# Composable Architecture"
+                    references/
+                      navigation.md "# Navigation"
+                  SQLiteData/
+                    SKILL.md "# SQLiteData"
+                token "deadbeef"
+          tmp/
+          """
+        }
+      }
+
+      @Test func antigravity() async throws {
+        try await assertCommand(["install", "--tool", "antigravity"]) {
+          """
+          Installed skills for antigravity into /Users/blob/.gemini/antigravity/global_skills
+          """
+        }
+        assertInlineSnapshot(of: fileSystem, as: .description) {
+          """
+          Users/
+            blob/
+              .gemini/
+                antigravity/
+                  global_skills/
+                    pfw-ComposableArchitecture@ -> /Users/blob/.pfw/skills/ComposableArchitecture
+                    pfw-SQLiteData@ -> /Users/blob/.pfw/skills/SQLiteData
+              .pfw/
+                machine "00000000-0000-0000-0000-000000000001"
+                sha "cafebeef"
+                skills/
+                  ComposableArchitecture/
+                    SKILL.md "# Composable Architecture"
+                    references/
+                      navigation.md "# Navigation"
+                  SQLiteData/
+                    SKILL.md "# SQLiteData"
+                token "deadbeef"
+          tmp/
+          """
+        }
+      }
+
+      @Test func opencode() async throws {
+        try await assertCommand(["install", "--tool", "opencode"]) {
+          """
+          Installed skills for opencode into /Users/blob/.config/opencode/skills
+          """
+        }
+        assertInlineSnapshot(of: fileSystem, as: .description) {
+          """
+          Users/
+            blob/
+              .config/
+                opencode/
+                  skills/
+                    pfw-ComposableArchitecture@ -> /Users/blob/.pfw/skills/ComposableArchitecture
+                    pfw-SQLiteData@ -> /Users/blob/.pfw/skills/SQLiteData
+              .pfw/
+                machine "00000000-0000-0000-0000-000000000001"
+                sha "cafebeef"
+                skills/
+                  ComposableArchitecture/
+                    SKILL.md "# Composable Architecture"
+                    references/
+                      navigation.md "# Navigation"
+                  SQLiteData/
+                    SKILL.md "# SQLiteData"
+                token "deadbeef"
+          tmp/
+          """
+        }
+      }
+
+      @Test func kimi() async throws {
+        try await assertCommand(["install", "--tool", "kimi"]) {
+          """
+          Installed skills for kimi into /Users/blob/.kimi/skills
+          """
+        }
+        assertInlineSnapshot(of: fileSystem, as: .description) {
+          """
+          Users/
+            blob/
+              .kimi/
+                skills/
+                  pfw-ComposableArchitecture@ -> /Users/blob/.pfw/skills/ComposableArchitecture
+                  pfw-SQLiteData@ -> /Users/blob/.pfw/skills/SQLiteData
+              .pfw/
+                machine "00000000-0000-0000-0000-000000000001"
+                sha "cafebeef"
+                skills/
+                  ComposableArchitecture/
+                    SKILL.md "# Composable Architecture"
+                    references/
+                      navigation.md "# Navigation"
+                  SQLiteData/
+                    SKILL.md "# SQLiteData"
+                token "deadbeef"
+          tmp/
+          """
+        }
+      }
+
+      @Test func droid() async throws {
+        try await assertCommand(["install", "--tool", "droid"]) {
+          """
+          Installed skills for droid into /Users/blob/.factory/skills
+          """
+        }
+        assertInlineSnapshot(of: fileSystem, as: .description) {
+          """
+          Users/
+            blob/
+              .factory/
+                skills/
+                  pfw-ComposableArchitecture@ -> /Users/blob/.pfw/skills/ComposableArchitecture
+                  pfw-SQLiteData@ -> /Users/blob/.pfw/skills/SQLiteData
+              .pfw/
+                machine "00000000-0000-0000-0000-000000000001"
+                sha "cafebeef"
+                skills/
+                  ComposableArchitecture/
+                    SKILL.md "# Composable Architecture"
+                    references/
+                      navigation.md "# Navigation"
+                  SQLiteData/
+                    SKILL.md "# SQLiteData"
+                token "deadbeef"
+          tmp/
+          """
+        }
+      }
+
       @Test func tildePath() async throws {
         try await assertCommand(["install", "--path", "~/.codex"]) {
           """


### PR DESCRIPTION
> **Note:** This PR depends on #8 and should be reviewed/merged after it.

## Summary

- Add 8 new AI tools to the `Tool` enum with their respective install paths
- Update README with supported tools table and documentation links
- Add tests for all new tools (45 total tests passing)

## Supported AI Tools

| Tool | Install Path | Documentation |
|------|--------------|---------------|
| Codex | `~/.codex/skills` | [OpenAI Codex Skills](https://developers.openai.com/codex/skills/) |
| Claude | `~/.claude/skills` | [Claude Code Skills](https://code.claude.com/docs/en/skills) |
| Cursor | `~/.cursor/skills` | [Cursor Skills](https://cursor.com/docs/context/skills) |
| Copilot | `~/.copilot/skills` | [GitHub Copilot Agent Skills](https://docs.github.com/en/copilot/concepts/agents/about-agent-skills) |
| Kiro | `~/.kiro/skills` | [Kiro Skills](https://kiro.dev/docs/cli/custom-agents/configuration-reference/#skill-resources) |
| Gemini | `~/.gemini/skills` | [Gemini CLI Skills](https://geminicli.com/docs/cli/skills/) |
| Antigravity | `~/.gemini/antigravity/global_skills` | [Antigravity Skills](https://antigravity.google/docs/skills) |
| OpenCode | `~/.config/opencode/skills` | [OpenCode Skills](https://opencode.ai/docs/skills/) |
| Kimi | `~/.kimi/skills` | [Kimi CLI Skills](https://moonshotai.github.io/kimi-cli/en/customization/skills) |
| Droid | `~/.factory/skills` | [Factory Droid Skills](https://docs.factory.ai/cli/configuration/skills) |

## Test plan

- [x] All 45 tests pass
- [x] Verified special paths for antigravity, opencode, and droid