### PR TITLE
Add support for AMP and a generic `.agents/skills` directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,3 +38,5 @@ A CLI tool for downloading and managing [Point-Free Way](https://www.pointfree.c
 | OpenCode | `~/.config/opencode/skills` | [OpenCode Skills](https://opencode.ai/docs/skills/) |
 | Kimi | `~/.kimi/skills` | [Kimi CLI Skills](https://moonshotai.github.io/kimi-cli/en/customization/skills) |
 | Droid | `~/.factory/skills` | [Factory Droid Skills](https://docs.factory.ai/cli/configuration/skills) |
+| Amp | `~/.amp/skills` | [Amp Agent Skills](https://ampcode.com/manual#agent-skills) |
+| Agents (generic) | `~/.agents/skills` | No public documentation |

--- a/Sources/pfw/Install.swift
+++ b/Sources/pfw/Install.swift
@@ -18,6 +18,8 @@ struct Install: AsyncParsableCommand {
     case opencode
     case kimi
     case droid
+    case amp
+    case agents
 
     var defaultInstallPath: URL {
       @Dependency(\.fileSystem) var fileSystem
@@ -40,6 +42,11 @@ struct Install: AsyncParsableCommand {
         return
           home
           .appending(path: ".factory")
+          .appending(path: "skills")
+      case .amp:
+        return
+          home
+          .appending(path: ".agents")
           .appending(path: "skills")
       default:
         return

--- a/Tests/pfwTests/InstallTests.swift
+++ b/Tests/pfwTests/InstallTests.swift
@@ -602,6 +602,66 @@ extension BaseSuite {
         }
       }
 
+      @Test func amp() async throws {
+        try await assertCommand(["install", "--tool", "amp"]) {
+          """
+          Installed skills for amp into /Users/blob/.agents/skills
+          """
+        }
+        assertInlineSnapshot(of: fileSystem, as: .description) {
+          """
+          Users/
+            blob/
+              .agents/
+                skills/
+                  pfw-ComposableArchitecture@ -> /Users/blob/.pfw/skills/ComposableArchitecture
+                  pfw-SQLiteData@ -> /Users/blob/.pfw/skills/SQLiteData
+              .pfw/
+                machine "00000000-0000-0000-0000-000000000001"
+                sha "cafebeef"
+                skills/
+                  ComposableArchitecture/
+                    SKILL.md "# Composable Architecture"
+                    references/
+                      navigation.md "# Navigation"
+                  SQLiteData/
+                    SKILL.md "# SQLiteData"
+                token "deadbeef"
+          tmp/
+          """
+        }
+      }
+
+      @Test func agents() async throws {
+        try await assertCommand(["install", "--tool", "agents"]) {
+          """
+          Installed skills for agents into /Users/blob/.agents/skills
+          """
+        }
+        assertInlineSnapshot(of: fileSystem, as: .description) {
+          """
+          Users/
+            blob/
+              .agents/
+                skills/
+                  pfw-ComposableArchitecture@ -> /Users/blob/.pfw/skills/ComposableArchitecture
+                  pfw-SQLiteData@ -> /Users/blob/.pfw/skills/SQLiteData
+              .pfw/
+                machine "00000000-0000-0000-0000-000000000001"
+                sha "cafebeef"
+                skills/
+                  ComposableArchitecture/
+                    SKILL.md "# Composable Architecture"
+                    references/
+                      navigation.md "# Navigation"
+                  SQLiteData/
+                    SKILL.md "# SQLiteData"
+                token "deadbeef"
+          tmp/
+          """
+        }
+      }
+
       @Test func tildePath() async throws {
         try await assertCommand(["install", "--path", "~/.codex"]) {
           """


### PR DESCRIPTION
PR similar to https://github.com/pointfreeco/pfw/pull/9, but adding AMP support and to a generic `~/.agents/skills` directory.

AI generated code:
* unit tests for `InstallTests.swift`

All tests pass locally.