### PR TITLE
Add `pfw list` command

### DIFF
--- a/Sources/pfw/List.swift
+++ b/Sources/pfw/List.swift
@@ -1,0 +1,58 @@
+import ArgumentParser
+import Dependencies
+import Foundation
+
+struct List: ParsableCommand {
+  static let configuration = CommandConfiguration(
+    abstract: "List installed skills."
+  )
+
+  func run() throws {
+    @Dependency(\.fileSystem) var fileSystem
+
+    let centralSkillsURL = pfwDirectoryURL.appendingPathComponent("skills", isDirectory: true)
+
+    guard fileSystem.fileExists(atPath: centralSkillsURL.path) else {
+      print("No skills installed. Run `pfw install` first.")
+      return
+    }
+
+    let skillDirectories = (try? fileSystem.contentsOfDirectory(at: centralSkillsURL)) ?? []
+    let skills = skillDirectories
+      .map { $0.lastPathComponent }
+      .sorted()
+
+    if skills.isEmpty {
+      print("No skills installed. Run `pfw install` first.")
+      return
+    }
+
+    print("Skills:")
+    for skill in skills {
+      print("  - \(skill)")
+    }
+
+    var installedTools: [(tool: Install.Tool, path: String)] = []
+    for tool in Install.Tool.allCases {
+      let toolPath = tool.defaultInstallPath
+      guard fileSystem.fileExists(atPath: toolPath.path) else { continue }
+
+      let contents = (try? fileSystem.contentsOfDirectory(at: toolPath)) ?? []
+      let hasPfwSymlinks = contents.contains { url in
+        url.lastPathComponent.hasPrefix("pfw-")
+      }
+
+      if hasPfwSymlinks {
+        installedTools.append((tool: tool, path: toolPath.path))
+      }
+    }
+
+    if !installedTools.isEmpty {
+      print("")
+      print("Installed for:")
+      for (tool, path) in installedTools.sorted(by: { $0.tool.rawValue < $1.tool.rawValue }) {
+        print("  \(tool.rawValue): \(path)")
+      }
+    }
+  }
+}

--- a/Sources/pfw/Main.swift
+++ b/Sources/pfw/Main.swift
@@ -12,6 +12,7 @@ struct PFW: AsyncParsableCommand {
       Login.self,
       Logout.self,
       Status.self,
+      List.self,
       Install.self,
     ]
   )

--- a/Tests/pfwTests/ListTests.swift
+++ b/Tests/pfwTests/ListTests.swift
@@ -1,0 +1,96 @@
+import Dependencies
+import DependenciesTestSupport
+import Foundation
+import Testing
+
+@testable import pfw
+
+extension BaseSuite {
+  @Suite @MainActor struct ListTests {
+    @Dependency(\.fileSystem, as: InMemoryFileSystem.self) var fileSystem
+
+    @Test func noSkillsDirectory() async throws {
+      try await assertCommand(["list"]) {
+        """
+        No skills installed. Run `pfw install` first.
+        """
+      }
+    }
+
+    @Test func emptySkillsDirectory() async throws {
+      try fileSystem.createDirectory(
+        at: URL(fileURLWithPath: "/Users/blob/.pfw/skills"),
+        withIntermediateDirectories: true
+      )
+      try await assertCommand(["list"]) {
+        """
+        No skills installed. Run `pfw install` first.
+        """
+      }
+    }
+
+    @Test func skillsInstalledNoTools() async throws {
+      let skillsURL = URL(fileURLWithPath: "/Users/blob/.pfw/skills")
+      try fileSystem.createDirectory(at: skillsURL, withIntermediateDirectories: true)
+      try fileSystem.createDirectory(
+        at: skillsURL.appendingPathComponent("ComposableArchitecture"),
+        withIntermediateDirectories: false
+      )
+      try fileSystem.createDirectory(
+        at: skillsURL.appendingPathComponent("Dependencies"),
+        withIntermediateDirectories: false
+      )
+
+      try await assertCommand(["list"]) {
+        """
+        Skills:
+          - ComposableArchitecture
+          - Dependencies
+        """
+      }
+    }
+
+    @Test func skillsInstalledWithTools() async throws {
+      let skillsURL = URL(fileURLWithPath: "/Users/blob/.pfw/skills")
+      try fileSystem.createDirectory(at: skillsURL, withIntermediateDirectories: true)
+      try fileSystem.createDirectory(
+        at: skillsURL.appendingPathComponent("ComposableArchitecture"),
+        withIntermediateDirectories: false
+      )
+      try fileSystem.createDirectory(
+        at: skillsURL.appendingPathComponent("Dependencies"),
+        withIntermediateDirectories: false
+      )
+
+      let claudeSkillsURL = URL(fileURLWithPath: "/Users/blob/.claude/skills")
+      try fileSystem.createDirectory(at: claudeSkillsURL, withIntermediateDirectories: true)
+      try fileSystem.createSymbolicLink(
+        at: claudeSkillsURL.appendingPathComponent("pfw-ComposableArchitecture"),
+        withDestinationURL: skillsURL.appendingPathComponent("ComposableArchitecture")
+      )
+      try fileSystem.createSymbolicLink(
+        at: claudeSkillsURL.appendingPathComponent("pfw-Dependencies"),
+        withDestinationURL: skillsURL.appendingPathComponent("Dependencies")
+      )
+
+      let cursorSkillsURL = URL(fileURLWithPath: "/Users/blob/.cursor/skills")
+      try fileSystem.createDirectory(at: cursorSkillsURL, withIntermediateDirectories: true)
+      try fileSystem.createSymbolicLink(
+        at: cursorSkillsURL.appendingPathComponent("pfw-ComposableArchitecture"),
+        withDestinationURL: skillsURL.appendingPathComponent("ComposableArchitecture")
+      )
+
+      try await assertCommand(["list"]) {
+        """
+        Skills:
+          - ComposableArchitecture
+          - Dependencies
+
+        Installed for:
+          claude: /Users/blob/.claude/skills
+          cursor: /Users/blob/.cursor/skills
+        """
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Adds a new `list` command that displays installed skills and which tools they're installed for.

Example output:
```
Skills:
  - CasePaths
  - ComposableArchitecture
  - CustomDump
  - Dependencies
  - IdentifiedCollections
  - ModernSwiftUI
  - ObservableModels
  - Perception
  - SQLiteData
  - Sharing
  - SnapshotTesting
  - StructuredQueries
  - SwiftNavigation
  - Testing

Installed for:
  antigravity: /Users/blob/.gemini/antigravity/global_skills
  claude: /Users/blob/.claude/skills
  codex: /Users/blob/.codex/skills
  copilot: /Users/blob/.copilot/skills
  cursor: /Users/blob/.cursor/skills
  droid: /Users/blob/.factory/skills
  kimi: /Users/blob/.kimi/skills
  opencode: /Users/blob/.config/opencode/skills
```

If you don't like this functionality or it doesn't fit the direction of pfw, feel free to close this PR.