### PR TITLE
Add local skill installs

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,14 @@ A CLI tool for downloading and managing [Point-Free Way](https://www.pointfree.c
     $ pfw install --tool codex
     ```
 
+4. **Install skills into the current working directory**
+
+    ```sh
+    $ pfw install --local
+    ```
+
+    `--local` defaults to `agents` when `--tool` is omitted.
+
 ## Supported AI Tools
 
 | `pfw install --tool` | Install Path |

--- a/Sources/pfw/Dependencies/FileSystem.swift
+++ b/Sources/pfw/Dependencies/FileSystem.swift
@@ -4,6 +4,7 @@ import ZIPFoundation
 
 protocol FileSystem: Sendable {
   var homeDirectoryForCurrentUser: URL { get }
+  var currentDirectoryPath: String { get }
   static var temporaryDirectory: URL { get }
   func createDirectory(at url: URL, withIntermediateDirectories createIntermediates: Bool) throws
   func removeItem(at url: URL) throws

--- a/Tests/pfwTests/InstallTests.swift
+++ b/Tests/pfwTests/InstallTests.swift
@@ -39,6 +39,14 @@ extension BaseSuite {
       }
     }
 
+    @Test func localCannotCombineWithPath() async throws {
+      await assertCommandThrows(["install", "--local", "--path", "/some/path"]) {
+        """
+        --local cannot be combined with --path.
+        """
+      }
+    }
+
     @Test(
       .dependencies { dependencies in
         try save(token: "expired-deadbeef")
@@ -906,6 +914,139 @@ extension BaseSuite {
           Changes since last install:
             • Added database migration guidance
             • Added TCA2.0
+          """
+        }
+      }
+
+      @Test func localDefaultsToAgents() async throws {
+        try await assertCommand(["install", "--local"]) {
+          """
+          Installed skills:
+            • agents: /Users/blob/project/.agents/skills
+          """
+        }
+        assertInlineSnapshot(of: fileSystem, as: .description) {
+          """
+          Users/
+            blob/
+              .pfw/
+                machine "00000000-0000-0000-0000-000000000001"
+                sha "cafebeef"
+                skills/
+                  ComposableArchitecture/
+                    SKILL.md "# Composable Architecture"
+                    references/
+                      navigation.md "# Navigation"
+                  SQLiteData/
+                    SKILL.md "# SQLiteData"
+                token "deadbeef"
+              project/
+                .agents/
+                  skills/
+                    pfw-ComposableArchitecture@ -> /Users/blob/.pfw/skills/ComposableArchitecture
+                    pfw-SQLiteData@ -> /Users/blob/.pfw/skills/SQLiteData
+          tmp/
+          """
+        }
+      }
+
+      @Test func localWithTool() async throws {
+        try await assertCommand(["install", "--local", "--tool", "codex"]) {
+          """
+          Installed skills:
+            • codex: /Users/blob/project/.codex/skills
+          """
+        }
+        assertInlineSnapshot(of: fileSystem, as: .description) {
+          """
+          Users/
+            blob/
+              .pfw/
+                machine "00000000-0000-0000-0000-000000000001"
+                sha "cafebeef"
+                skills/
+                  ComposableArchitecture/
+                    SKILL.md "# Composable Architecture"
+                    references/
+                      navigation.md "# Navigation"
+                  SQLiteData/
+                    SKILL.md "# SQLiteData"
+                token "deadbeef"
+              project/
+                .codex/
+                  skills/
+                    pfw-ComposableArchitecture@ -> /Users/blob/.pfw/skills/ComposableArchitecture
+                    pfw-SQLiteData@ -> /Users/blob/.pfw/skills/SQLiteData
+          tmp/
+          """
+        }
+      }
+
+      @Test func localWithMultipleTools() async throws {
+        try await assertCommand(["install", "--local", "--tool", "codex", "--tool", "claude"]) {
+          """
+          Installed skills:
+            • codex: /Users/blob/project/.codex/skills
+            • claude: /Users/blob/project/.claude/skills
+          """
+        }
+        assertInlineSnapshot(of: fileSystem, as: .description) {
+          """
+          Users/
+            blob/
+              .pfw/
+                machine "00000000-0000-0000-0000-000000000001"
+                sha "cafebeef"
+                skills/
+                  ComposableArchitecture/
+                    SKILL.md "# Composable Architecture"
+                    references/
+                      navigation.md "# Navigation"
+                  SQLiteData/
+                    SKILL.md "# SQLiteData"
+                token "deadbeef"
+              project/
+                .claude/
+                  skills/
+                    pfw-ComposableArchitecture@ -> /Users/blob/.pfw/skills/ComposableArchitecture
+                    pfw-SQLiteData@ -> /Users/blob/.pfw/skills/SQLiteData
+                .codex/
+                  skills/
+                    pfw-ComposableArchitecture@ -> /Users/blob/.pfw/skills/ComposableArchitecture
+                    pfw-SQLiteData@ -> /Users/blob/.pfw/skills/SQLiteData
+          tmp/
+          """
+        }
+      }
+
+      @Test func localWithOpencode() async throws {
+        try await assertCommand(["install", "--local", "--tool", "opencode"]) {
+          """
+          Installed skills:
+            • opencode: /Users/blob/project/.opencode/skills
+          """
+        }
+        assertInlineSnapshot(of: fileSystem, as: .description) {
+          """
+          Users/
+            blob/
+              .pfw/
+                machine "00000000-0000-0000-0000-000000000001"
+                sha "cafebeef"
+                skills/
+                  ComposableArchitecture/
+                    SKILL.md "# Composable Architecture"
+                    references/
+                      navigation.md "# Navigation"
+                  SQLiteData/
+                    SKILL.md "# SQLiteData"
+                token "deadbeef"
+              project/
+                .opencode/
+                  skills/
+                    pfw-ComposableArchitecture@ -> /Users/blob/.pfw/skills/ComposableArchitecture
+                    pfw-SQLiteData@ -> /Users/blob/.pfw/skills/SQLiteData
+          tmp/
           """
         }
       }

--- a/Tests/pfwTests/Internal/InMemoryFileSystem.swift
+++ b/Tests/pfwTests/Internal/InMemoryFileSystem.swift
@@ -17,12 +17,14 @@ final class InMemoryFileSystem: FileSystem {
     var directories: Set<String>
     var symbolicLinks: [String: String]
     var homeDirectoryForCurrentUser: URL
+    var currentDirectoryPath: String
   }
 
   let state: LockIsolated<State>
 
   init(
     homeDirectoryForCurrentUser: URL = URL(fileURLWithPath: "/Users/blob"),
+    currentDirectoryPath: String = "/Users/blob/project",
     files: [String: Data] = [:],
     directories: Set<String> = []
   ) {
@@ -30,7 +32,8 @@ final class InMemoryFileSystem: FileSystem {
       files: files,
       directories: directories,
       symbolicLinks: [:],
-      homeDirectoryForCurrentUser: homeDirectoryForCurrentUser
+      homeDirectoryForCurrentUser: homeDirectoryForCurrentUser,
+      currentDirectoryPath: currentDirectoryPath
     )
     self.state = LockIsolated(state)
     self.state.withValue {
@@ -127,6 +130,10 @@ final class InMemoryFileSystem: FileSystem {
 
   var homeDirectoryForCurrentUser: URL {
     state.withValue { $0.homeDirectoryForCurrentUser }
+  }
+
+  var currentDirectoryPath: String {
+    state.withValue { $0.currentDirectoryPath }
   }
 
   static var temporaryDirectory: URL {


### PR DESCRIPTION
## `--local`: project-scoped skill installs

Skills currently install to the user's home directory, which means every project on your machine shares the same set. The new `--local` flag drops symlinks into the *current working directory* instead, so you can version-control exactly which skills a repo uses.

```sh
pfw install --local              # defaults to .agents/skills
pfw install --local --tool codex # .codex/skills in the project root
```

`--local` cannot be combined with `--path` (you already know where you want things).

Includes validation, a `localInstallPath` helper, `currentDirectoryPath` on `FileSystem`, and tests covering agents-default, single tool, multi-tool, and opencode variants.