### PR TITLE
Ignore non-directory entries in skill folders

### DIFF
--- a/Sources/pfw/Dependencies/FileSystem.swift
+++ b/Sources/pfw/Dependencies/FileSystem.swift
@@ -8,6 +8,7 @@ protocol FileSystem: Sendable {
   func createDirectory(at url: URL, withIntermediateDirectories createIntermediates: Bool) throws
   func removeItem(at url: URL) throws
   func fileExists(atPath path: String) -> Bool
+  func isDirectory(atPath path: String) -> Bool
   func write(_ data: Data, to url: URL) throws
   func data(at url: URL) throws -> Data
   func createSymbolicLink(at url: URL, withDestinationURL destURL: URL) throws
@@ -28,6 +29,14 @@ extension FileManager: FileSystem {
 
   static var temporaryDirectory: URL {
     URL.temporaryDirectory
+  }
+
+  func isDirectory(atPath path: String) -> Bool {
+    var isDirectory = ObjCBool(false)
+    guard fileExists(atPath: path, isDirectory: &isDirectory) else {
+      return false
+    }
+    return isDirectory.boolValue
   }
 
   func write(_ data: Data, to url: URL) throws {

--- a/Sources/pfw/Install.swift
+++ b/Sources/pfw/Install.swift
@@ -189,7 +189,9 @@ struct Install: AsyncParsableCommand {
         try? fileSystem.removeItem(at: url)
       }
 
-      let skillDirectories = (try? fileSystem.contentsOfDirectory(at: skillsSourceURL)) ?? []
+      let skillDirectories =
+        ((try? fileSystem.contentsOfDirectory(at: skillsSourceURL)) ?? [])
+        .filter { fileSystem.isDirectory(atPath: $0.path) }
       for directory in skillDirectories {
         guard directory.lastPathComponent != "commit-messages.json"
         else { continue }
@@ -223,7 +225,8 @@ struct Install: AsyncParsableCommand {
       }
 
       let centralSkillDirectories =
-        (try? fileSystem.contentsOfDirectory(at: centralSkillsURL)) ?? []
+        ((try? fileSystem.contentsOfDirectory(at: centralSkillsURL)) ?? [])
+        .filter { fileSystem.isDirectory(atPath: $0.path) }
       for directory in centralSkillDirectories {
         try fileSystem.write(Data("*\n".utf8), to: directory.appendingPathComponent(".gitignore"))
         let toolDestination = skillsURL.appendingPathComponent("pfw-\(directory.lastPathComponent)")

--- a/Sources/pfw/List.swift
+++ b/Sources/pfw/List.swift
@@ -17,7 +17,9 @@ struct List: ParsableCommand {
       return
     }
 
-    let skillDirectories = (try? fileSystem.contentsOfDirectory(at: centralSkillsURL)) ?? []
+    let skillDirectories =
+      ((try? fileSystem.contentsOfDirectory(at: centralSkillsURL)) ?? [])
+      .filter { fileSystem.isDirectory(atPath: $0.path) }
     let skills =
       skillDirectories
       .map { $0.lastPathComponent }

--- a/Tests/pfwTests/InstallTests.swift
+++ b/Tests/pfwTests/InstallTests.swift
@@ -254,6 +254,67 @@ extension BaseSuite {
         }
       }
 
+      @Test(
+        .dependencies {
+          try await $0.login()
+          $0.pointFreeServer = InMemoryPointFreeServer(result: .success(.notModified))
+          try $0.fileSystem.createDirectory(
+            at: URL(filePath: "/Users/blob/.pfw/skills/ComposableArchitecture"),
+            withIntermediateDirectories: true
+          )
+          try $0.fileSystem.write(
+            Data("# Composable Architecture".utf8),
+            to: URL(filePath: "/Users/blob/.pfw/skills/ComposableArchitecture/SKILL.md")
+          )
+          try $0.fileSystem.createDirectory(
+            at: URL(filePath: "/Users/blob/.pfw/skills/SQLiteData"),
+            withIntermediateDirectories: true
+          )
+          try $0.fileSystem.write(
+            Data("# SQLiteData".utf8),
+            to: URL(filePath: "/Users/blob/.pfw/skills/SQLiteData/SKILL.md")
+          )
+          try $0.fileSystem.write(
+            Data(),
+            to: URL(filePath: "/Users/blob/.pfw/skills/.DS_Store")
+          )
+          try save(sha: "cafebeef")
+        }
+      )
+      func upToDateIgnoresFilesInCentralSkillsDirectory() async throws {
+        try await assertCommand(["install", "--tool", "codex"]) {
+          """
+          Skills up-to-date.
+          Installed skills:
+            • codex: /Users/blob/.codex/skills
+          """
+        }
+
+        assertInlineSnapshot(of: fileSystem, as: .description) {
+          #"""
+          Users/
+            blob/
+              .codex/
+                skills/
+                  pfw-ComposableArchitecture@ -> /Users/blob/.pfw/skills/ComposableArchitecture
+                  pfw-SQLiteData@ -> /Users/blob/.pfw/skills/SQLiteData
+              .pfw/
+                machine "00000000-0000-0000-0000-000000000002"
+                sha "cafebeef"
+                skills/
+                  .DS_Store ""
+                  ComposableArchitecture/
+                    .gitignore "*\n"
+                    SKILL.md "# Composable Architecture"
+                  SQLiteData/
+                    .gitignore "*\n"
+                    SKILL.md "# SQLiteData"
+                token "deadbeef"
+          tmp/
+          """#
+        }
+      }
+
       @Test func multipleTools() async throws {
         try await assertCommand(["install", "--tool", "codex", "--tool", "claude"]) {
           """

--- a/Tests/pfwTests/Internal/InMemoryFileSystem.swift
+++ b/Tests/pfwTests/Internal/InMemoryFileSystem.swift
@@ -107,6 +107,13 @@ final class InMemoryFileSystem: FileSystem {
     }
   }
 
+  func isDirectory(atPath path: String) -> Bool {
+    let normalizedPath = normalize(path)
+    return state.withValue { state in
+      state.directories.contains(normalizedPath)
+    }
+  }
+
   func unzipItem(
     at sourceURL: URL, to destinationURL: URL
   ) throws {

--- a/Tests/pfwTests/ListTests.swift
+++ b/Tests/pfwTests/ListTests.swift
@@ -92,5 +92,22 @@ extension BaseSuite {
         """
       }
     }
+
+    @Test func skillsInstalledIgnoresFiles() async throws {
+      let skillsURL = URL(fileURLWithPath: "/Users/blob/.pfw/skills")
+      try fileSystem.createDirectory(at: skillsURL, withIntermediateDirectories: true)
+      try fileSystem.createDirectory(
+        at: skillsURL.appendingPathComponent("ComposableArchitecture"),
+        withIntermediateDirectories: false
+      )
+      try fileSystem.write(Data(), to: skillsURL.appendingPathComponent(".DS_Store"))
+
+      try await assertCommand(["list"]) {
+        """
+        Skills:
+          - ComposableArchitecture
+        """
+      }
+    }
   }
 }


### PR DESCRIPTION
## Summary

Ignore non-directory entries when reading skill folders.

`pfw install` and `pfw list` currently assume every entry returned from the skills directories is itself a skill directory. On macOS that breaks when Finder drops `.DS_Store` into `~/.pfw/skills` or a tool skills directory.

## Reproduction

On `pfw 0.0.8`:

1. Ensure `~/.pfw/skills/.DS_Store` exists.
2. Run:

```sh
pfw install --tool agents
```

3. The install can fail with:

```text
Skills up-to-date.
Installed skills:
Error: The file “.gitignore” couldn’t be saved in the folder “.DS_Store”.
```

`pfw list` can also incorrectly treat file entries in `~/.pfw/skills` as installed skills.

## Fix

- Add `isDirectory(atPath:)` to the `FileSystem` abstraction.
- Filter `contentsOfDirectory` results to actual directories before moving downloaded skills, writing `.gitignore`, linking installed skills, or listing installed skills.

## Testing

```sh
swift test
```
