### PR TITLE
Update pi skill install path

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,6 @@ A CLI tool for downloading and managing [Point-Free Way](https://www.pointfree.c
 | [`kimi`](https://moonshotai.github.io/kimi-cli/en/customization/skills) | `~/.kimi/skills` |
 | [`kiro`](https://kiro.dev/docs/cli/custom-agents/configuration-reference/#skill-resources) | `~/.kiro/skills` |
 | [`opencode`](https://opencode.ai/docs/skills/) | `~/.config/opencode/skills` |
-| [`pi`](https://github.com/badlogic/pi-mono/tree/main/packages/coding-agent#skills) | `~/.pi/skills` |
+| [`pi`](https://github.com/badlogic/pi-mono/tree/main/packages/coding-agent#skills) | `~/.pi/agent/skills` |
 | [`xcode:claude`](https://developer.apple.com/documentation/Xcode/setting-up-coding-intelligence#Customize-the-Codex-and-Claude-Agent-environments) | `~/Library/Developer/Xcode/CodingAssistant/ClaudeAgentConfig/skills` |
 | [`xcode:codex`](https://developer.apple.com/documentation/Xcode/setting-up-coding-intelligence#Customize-the-Codex-and-Claude-Agent-environments) | `~/Library/Developer/Xcode/CodingAssistant/codex/skills` |

--- a/Sources/pfw/Install.swift
+++ b/Sources/pfw/Install.swift
@@ -37,6 +37,8 @@ struct Install: AsyncParsableCommand {
         return home.appending(path: ".factory/skills")
       case .opencode:
         return home.appending(path: ".config/opencode/skills")
+      case .pi:
+        return home.appending(path: ".pi/agent/skills")
       case .xcodeClaude:
         return home.appending(
           path: "Library/Developer/Xcode/CodingAssistant/ClaudeAgentConfig/skills"

--- a/Tests/pfwTests/InstallTests.swift
+++ b/Tests/pfwTests/InstallTests.swift
@@ -662,7 +662,7 @@ extension BaseSuite {
         try await assertCommand(["install", "--tool", "pi"]) {
           """
           Installed skills:
-            • pi: /Users/blob/.pi/skills
+            • pi: /Users/blob/.pi/agent/skills
           """
         }
         assertInlineSnapshot(of: fileSystem, as: .description) {
@@ -683,9 +683,10 @@ extension BaseSuite {
                     SKILL.md "# SQLiteData"
                 token "deadbeef"
               .pi/
-                skills/
-                  pfw-ComposableArchitecture@ -> /Users/blob/.pfw/skills/ComposableArchitecture
-                  pfw-SQLiteData@ -> /Users/blob/.pfw/skills/SQLiteData
+                agent/
+                  skills/
+                    pfw-ComposableArchitecture@ -> /Users/blob/.pfw/skills/ComposableArchitecture
+                    pfw-SQLiteData@ -> /Users/blob/.pfw/skills/SQLiteData
           tmp/
           """#
         }


### PR DESCRIPTION
Added an override for `pfw install` command to use `~/.pi/agent/skills` as the install path.

This partially resolves #46 .