### PR TITLE
Add xcode:gemini install tool

### DIFF
--- a/Sources/pfw/Install.swift
+++ b/Sources/pfw/Install.swift
@@ -23,6 +23,7 @@ struct Install: AsyncParsableCommand {
     case pi
     case xcodeClaude = "xcode:claude"
     case xcodeCodex = "xcode:codex"
+    case xcodeGemini = "xcode:gemini"
 
     var defaultInstallPath: URL {
       @Dependency(\.fileSystem) var fileSystem
@@ -45,6 +46,10 @@ struct Install: AsyncParsableCommand {
         )
       case .xcodeCodex:
         return home.appending(path: "Library/Developer/Xcode/CodingAssistant/codex/skills")
+      case .xcodeGemini:
+        return home.appending(
+          path: "Library/Developer/Xcode/CodingAssistant/gemini/.gemini/skills"
+        )
       default:
         return home.appending(path: ".\(rawValue)/skills")
       }


### PR DESCRIPTION
Installs skills to Library/Developer/Xcode/CodingAssistant/gemini/.gemini/skills, mirroring the existing `xcode:claude` pattern.