### PR TITLE
More correct determinantion of skill directories.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
     strategy:
       matrix:
         swift:
-          - '6.2.3'
+          - '6.3.0'
     steps:
       - uses: actions/checkout@v5
       - name: Install Swift ${{ matrix.swift }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,11 +35,8 @@ jobs:
       matrix:
         swift:
           - '6.3.0'
+    container: swift:${{ matrix.swift }}
     steps:
       - uses: actions/checkout@v5
-      - name: Install Swift ${{ matrix.swift }}
-        uses: swift-actions/setup-swift@v3
-        with:
-          swift-version: ${{ matrix.swift }}
       - name: Test
         run: swift test

--- a/Sources/pfw/Install.swift
+++ b/Sources/pfw/Install.swift
@@ -196,10 +196,8 @@ struct Install: AsyncParsableCommand {
         try? fileSystem.removeItem(at: url)
       }
 
-      let skillDirectories = (try? fileSystem.contentsOfDirectory(at: skillsSourceURL)) ?? []
+      let skillDirectories = fileSystem.loadSkillDirectories(from: skillsSourceURL)
       for directory in skillDirectories {
-        guard directory.lastPathComponent != "commit-messages.json"
-        else { continue }
         let centralDestination = centralSkillsURL.appendingPathComponent(
           directory.lastPathComponent
         )
@@ -229,8 +227,7 @@ struct Install: AsyncParsableCommand {
         try? fileSystem.removeItem(at: url)
       }
 
-      let centralSkillDirectories =
-        (try? fileSystem.contentsOfDirectory(at: centralSkillsURL)) ?? []
+      let centralSkillDirectories = fileSystem.loadSkillDirectories(from: centralSkillsURL)
       for directory in centralSkillDirectories {
         try fileSystem.write(Data("*\n".utf8), to: directory.appendingPathComponent(".gitignore"))
         let toolDestination = skillsURL.appendingPathComponent("pfw-\(directory.lastPathComponent)")
@@ -267,4 +264,11 @@ private func loadCommitMessages(
 ) -> [String]? {
   guard let data = try? fileSystem.data(at: url) else { return nil }
   return try? JSONDecoder().decode([String].self, from: data)
+}
+
+extension FileSystem {
+  fileprivate func loadSkillDirectories(from url: URL) -> [URL] {
+    ((try? contentsOfDirectory(at: url)) ?? [])
+      .filter { fileExists(atPath: $0.appendingPathComponent("SKILL.md").path) }
+  }
 }

--- a/Tests/pfwTests/InstallTests.swift
+++ b/Tests/pfwTests/InstallTests.swift
@@ -986,6 +986,52 @@ extension BaseSuite {
           """
         }
       }
+
+      @Test(
+        .dependencies {
+          try await $0.login()
+          $0.pointFreeServer = InMemoryPointFreeServer(result: .success(.notModified))
+          try $0.fileSystem.createDirectory(
+            at: URL(filePath: "/Users/blob/.pfw/skills/ComposableArchitecture"),
+            withIntermediateDirectories: true
+          )
+          try $0.fileSystem.write(
+            Data("# Composable Architecture".utf8),
+            to: URL(filePath: "/Users/blob/.pfw/skills/ComposableArchitecture/SKILL.md")
+          )
+          try $0.fileSystem.write(
+            Data(),
+            to: URL(filePath: "/Users/blob/.pfw/skills/.DS_Store")
+          )
+        }
+      )
+      func ignoresDSStoreInExistingCentralSkills() async throws {
+        try await assertCommand(["install", "--tool", "codex"]) {
+          """
+          Skills up-to-date.
+          Installed skills:
+            • codex: /Users/blob/.codex/skills
+          """
+        }
+        assertInlineSnapshot(of: fileSystem, as: .description) {
+          #"""
+          Users/
+            blob/
+              .codex/
+                skills/
+                  pfw-ComposableArchitecture@ -> /Users/blob/.pfw/skills/ComposableArchitecture
+              .pfw/
+                machine "00000000-0000-0000-0000-000000000002"
+                skills/
+                  .DS_Store ""
+                  ComposableArchitecture/
+                    .gitignore "*\n"
+                    SKILL.md "# Composable Architecture"
+                token "deadbeef"
+          tmp/
+          """#
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
Right now we assume everything in `.pfw` is a directory, even though it can contain other things. We even have special logic for commit-messages.json, but an errant `.DS_Store` can also sneak in. So I've tightened up the logic that determines which directories are actually skills.